### PR TITLE
Add a simple test, fix dep warnings, add TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: julia
+os:
+    - linux
+    - osx
+julia:
+    - 0.3
+    - 0.4
+    - nightly
+notifications:
+    email: false
+sudo: false

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Loess
 
+[![Build Status](https://travis-ci.org/dcjones/Loess.jl.svg?branch=master)](https://travis-ci.org/dcjones/Loess.jl)
+[![Loess](http://pkg.julialang.org/badges/Loess_0.3.svg)](http://pkg.julialang.org/?pkg=Loess)
+[![Loess](http://pkg.julialang.org/badges/Loess_0.4.svg)](http://pkg.julialang.org/?pkg=Loess)
+
 This is a pure Julia loess implementation, based on the fast kd-tree based
 approximation described in the original Cleveland, et al papers, implemented
 in the netlib loess C/Fortran code, and used by many, including in R's loess

--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -1,4 +1,4 @@
-VERSION >= v"0.4.0-dev+6641" && __precompile__()
+isdefined(Base, :__precompile__) && __precompile__()
 
 module Loess
 
@@ -12,7 +12,7 @@ export loess, predict
 include("kd.jl")
 
 
-type LoessModel{T <: FloatingPoint}
+type LoessModel{T <: AbstractFloat}
 	# An n by m predictor matrix containing n observations from m predictors
 	xs::AbstractMatrix{T}
 
@@ -42,13 +42,13 @@ end
 # Returns:
 #   A fit LoessModel.
 #
-function loess{T <: FloatingPoint}(xs::AbstractVector{T}, ys::AbstractVector{T};
+function loess{T <: AbstractFloat}(xs::AbstractVector{T}, ys::AbstractVector{T};
 	                            	   normalize::Bool=true, span::T=0.75, degree::Int=2)
 	loess(reshape(xs, (length(xs), 1)), ys, normalize=normalize, span=span, degree=degree)
 end
 
 
-function loess{T <: FloatingPoint}(xs::AbstractMatrix{T}, ys::AbstractVector{T};
+function loess{T <: AbstractFloat}(xs::AbstractMatrix{T}, ys::AbstractVector{T};
 	                               normalize::Bool=true, span::T=0.75, degree::Int=2)
 	if size(xs, 1) != size(ys, 1)
 		error("Predictor and response arrays must of the same length")
@@ -134,12 +134,12 @@ end
 # Returns:
 #   A length n' vector of predicted response values.
 #
-function predict{T <: FloatingPoint}(model::LoessModel{T}, z::T)
+function predict{T <: AbstractFloat}(model::LoessModel{T}, z::T)
 	predict(model, T[z])
 end
 
 
-function predict{T <: FloatingPoint}(model::LoessModel{T}, zs::AbstractVector{T})
+function predict{T <: AbstractFloat}(model::LoessModel{T}, zs::AbstractVector{T})
 	m = size(model.xs, 2)
 
 	# in the univariate case, interpret a non-singleton zs as vector of
@@ -172,7 +172,7 @@ function predict{T <: FloatingPoint}(model::LoessModel{T}, zs::AbstractVector{T}
 end
 
 
-function predict{T <: FloatingPoint}(model::LoessModel{T}, zs::AbstractMatrix{T})
+function predict{T <: AbstractFloat}(model::LoessModel{T}, zs::AbstractMatrix{T})
 	ys = Array(T, size(zs, 1))
 	for i in 1:size(zs, 1)
 		ys[i] = predict(model, vec(zs[i,:]))
@@ -223,7 +223,7 @@ end
 # Modifies:
 #   xs
 #
-function normalize!{T <: FloatingPoint}(xs::AbstractMatrix{T}, q::T=0.100000000000000000001)
+function normalize!{T <: AbstractFloat}(xs::AbstractMatrix{T}, q::T=0.100000000000000000001)
 	n, m = size(xs)
 	cut = ceil(Integer, (q * n))
 	tmp = Array(T, n)

--- a/src/kd.jl
+++ b/src/kd.jl
@@ -6,7 +6,7 @@ using Compat
 abstract KDNode
 
 
-immutable KDTree{T <: FloatingPoint}
+immutable KDTree{T <: AbstractFloat}
 	# A matrix of n, m-dimensional observations
 	xs::AbstractMatrix{T}
 
@@ -36,7 +36,7 @@ end
 # Returns:
 #   A KDTree object
 #
-function KDTree{T <: FloatingPoint}(xs::AbstractMatrix{T},
+function KDTree{T <: AbstractFloat}(xs::AbstractMatrix{T},
 	                                leaf_size_factor=0.05,
 	                                leaf_diameter_factor=0.0)
 	n, m = size(xs)
@@ -70,7 +70,7 @@ immutable KDLeafNode <: KDNode
 end
 
 
-immutable KDInternalNode{T <: FloatingPoint} <: KDNode
+immutable KDInternalNode{T <: AbstractFloat} <: KDNode
 	j::Int # dimension on which the data is split
 	med::T # median value where the split occours
 	leftnode::KDNode

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,16 @@
+# These tests don't do much except ensure that the package loads,
+# and does something sensible if it does.
+using Loess
+using Base.Test
+
+srand(100)
+xs = 10 .* rand(100)
+ys = sin(xs) .+ 0.5 * rand(100)
+
+model = loess(xs, ys)
+
+us = collect(minimum(xs):0.1:maximum(xs))
+vs = predict(model, us) 
+
+@test minimum(vs) >= -1.1
+@test maximum(vs) <= +1.1


### PR DESCRIPTION
You'd need to turn on Travis yourself (and tag, naturally)

This cuts down on a fairly large number of dep warnings from compiling Gadfly.

(This package could possibly move to JuliaStats if you don't want to concern yourself with it too much, as well)