### PR TITLE
Fix breakage due to array indexing change.

### DIFF
--- a/src/Loess.jl
+++ b/src/Loess.jl
@@ -175,6 +175,7 @@ end
 function predict{T <: AbstractFloat}(model::LoessModel{T}, zs::AbstractMatrix{T})
 	ys = Array(T, size(zs, 1))
 	for i in 1:size(zs, 1)
+		# the vec() here is not necessary on 0.5 anymore
 		ys[i] = predict(model, vec(zs[i,:]))
 	end
 	ys
@@ -204,7 +205,7 @@ function evalpoly(xs, bs)
 		x = xs[i]
 		xx = x
 		for l in 1:degree
-			y += xx * bs[i, 1 + (i-1)*degree + l]
+			y += xx * bs[1 + (i-1)*degree + l]
 			xx *= x
 		end
 	end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ ys = sin(xs) .+ 0.5 * rand(100)
 model = loess(xs, ys)
 
 us = collect(minimum(xs):0.1:maximum(xs))
-vs = predict(model, us) 
+vs = predict(model, us)
 
 @test minimum(vs) >= -1.1
 @test maximum(vs) <= +1.1


### PR DESCRIPTION
This fixes the test on 0.5 master. However, I'm a little bit confused by `evalpoly` and it's usage.

The only use of `evalpoly` takes a `1xn` matrix (since the value type of `model.verts`) as `bs`. It is then indexed with the first index up to `length(xs)`. `length(xs)` seems to be always one throughout the test which IMHO either means that this is always true and the confusing indexing should be dropped, or something else should be fixed (if `length(xs) == 1` is not always true). Given the manual calculation of the second index that include `i`, I'm guessing the first index can simply be dropped (and just use linear indexing of the array directly)?
